### PR TITLE
mingw-w64-clang-toolchain

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1185,7 +1185,7 @@ optional("pdf") {
 }
 
 optional("xps") {
-  enabled = skia_use_xps && is_win && !is_mingw
+  enabled = skia_use_xps && is_win
   public_defines = [ "SK_SUPPORT_XPS" ]
   public = skia_xps_public
   sources = skia_xps_sources

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -182,6 +182,9 @@ opts("ssse3") {
   sources = skia_opts.ssse3_sources
   if (!is_clang && is_win) {
     defines = [ "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3" ]
+    if (is_mingw) {
+        cflags = [ "-mssse3" ]
+    }
   } else {
     cflags = [ "-mssse3" ]
   }
@@ -192,6 +195,9 @@ opts("sse42") {
   sources = skia_opts.sse42_sources
   if (!is_clang && is_win) {
     defines = [ "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSE42" ]
+    if (is_mingw) {
+        cflags = [ "-msse4.2" ]
+    }
   } else {
     cflags = [ "-msse4.2" ]
   }
@@ -200,7 +206,7 @@ opts("sse42") {
 opts("avx") {
   enabled = is_x86
   sources = skia_opts.avx_sources
-  if (is_win) {
+  if (is_win && !is_mingw) {
     cflags = [ "/arch:AVX" ]
   } else {
     cflags = [ "-mavx" ]
@@ -213,7 +219,7 @@ opts("avx") {
 opts("hsw") {
   enabled = is_x86
   sources = skia_opts.hsw_sources
-  if (is_win) {
+  if (is_win && !is_mingw) {
     cflags = [ "/arch:AVX2" ]
   } else {
     cflags = [ "-march=haswell" ]
@@ -226,7 +232,7 @@ opts("hsw") {
 opts("skx") {
   enabled = is_x86
   sources = skia_opts.skx_sources
-  if (is_win) {
+  if (is_win && !is_mingw) {
     cflags = [ "/arch:AVX512" ]
   } else {
     cflags = [ "-march=skylake-avx512" ]
@@ -554,7 +560,11 @@ optional("fontmgr_win_gdi") {
 
   public = [ "include/ports/SkTypeface_win.h" ]
   sources = [ "src/ports/SkFontHost_win.cpp" ]
-  libs = [ "Gdi32.lib" ]
+  if (!is_mingw){
+    libs = [ "Gdi32.lib" ]
+  } else {
+    libs = [ "gdi32" ]
+  }
 }
 
 if (skia_lex) {
@@ -930,7 +940,11 @@ optional("gpu") {
     } else if (is_win && !skia_enable_winuwp) {
       sources += [ "src/gpu/ganesh/gl/win/GrGLMakeNativeInterface_win.cpp" ]
       if (target_cpu != "arm64") {
-        libs += [ "OpenGL32.lib" ]
+        if (!is_mingw){
+            libs += [ "OpenGL32.lib" ]
+        } else {
+            libs += [ "opengl32" ]
+        }
       }
     } else {
       sources += [ "src/gpu/ganesh/gl/GrGLMakeNativeInterface_none.cpp" ]
@@ -1171,7 +1185,7 @@ optional("pdf") {
 }
 
 optional("xps") {
-  enabled = skia_use_xps && is_win
+  enabled = skia_use_xps && is_win && !is_mingw
   public_defines = [ "SK_SUPPORT_XPS" ]
   public = skia_xps_public
   sources = skia_xps_sources
@@ -1411,17 +1425,33 @@ skia_component("skia") {
       "src/ports/SkOSFile_win.cpp",
       "src/ports/SkOSLibrary_win.cpp",
     ]
-    libs += [
-      "Ole32.lib",
-      "OleAut32.lib",
-    ]
+    if (!is_mingw){
+        libs += [
+          "Ole32.lib",
+          "OleAut32.lib",
+        ]
+    } else {
+        libs += [
+          "ole32",
+          "oleaut32",
+          "uuid"
+        ]
+    }
 
     if (!skia_enable_winuwp) {
-      libs += [
-        "FontSub.lib",
-        "User32.lib",
-        "Usp10.lib",
-      ]
+      if (!is_mingw){
+          libs += [
+            "FontSub.lib",
+            "User32.lib",
+            "Usp10.lib",
+          ]
+      } else {
+          libs += [
+            "fontsub",
+            "user32",
+            "usp10"
+          ]
+      }
     }
   } else {
     sources += [
@@ -1854,9 +1884,17 @@ if (skia_enable_tools) {
         ]
       } else if (is_win) {
         sources += [ "tools/gpu/gl/win/CreatePlatformGLTestContext_win.cpp" ]
-        libs += [ "Gdi32.lib" ]
+        if (!is_mingw){
+            libs += [ "Gdi32.lib" ]
+        } else {
+            libs += [ "gdi32" ]
+        }
         if (target_cpu != "arm64") {
-          libs += [ "OpenGL32.lib" ]
+            if (!is_mingw){
+                libs += [ "OpenGL32.lib" ]
+            } else {
+                libs += [ "opengl32" ]
+            }
         }
       }
     }

--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -18,8 +18,8 @@ declare_args() {
   sanitize = ""
 
   ar = "ar"
-  cc = "cc"
-  cxx = "c++"
+  cc = "clang"
+  cxx = "clang++"
 
   win_sdk = "C:/Program Files (x86)/Windows Kits/10"
   win_sdk_version = ""
@@ -63,6 +63,12 @@ is_linux = current_os == "linux"
 is_mac = current_os == "mac"
 is_wasm = current_os == "wasm"
 is_win = current_os == "win"
+
+# Set to true when compiling with the MinGW GCC compiler on the MSYS2 environment
+is_mingw = exec_script("//gn/is_mingw.py",
+                [cc],
+                "value")
+
 
 # This is just to make the Dawn build files happy. Skia itself uses target_os = "linux"
 # for ChromeOS, so this variable will not affect Skia proper.
@@ -123,7 +129,7 @@ if (is_android) {
   }
 }
 
-if (target_os == "win") {
+if (target_os == "win" && !is_mingw) {
   # By default we look for 2017 (Enterprise, Pro, and Community), then 2015. If MSVC is installed in a
   # non-default location, you can set win_vc to inform us where it is.
 
@@ -134,7 +140,7 @@ if (target_os == "win") {
                         # directory.
 }
 
-if (target_os == "win") {
+if (target_os == "win" && !is_mingw) {
   if (win_toolchain_version == "") {
     win_toolchain_version = exec_script("//gn/highest_version_dir.py",
                                         [
@@ -224,7 +230,7 @@ if (!is_official_build) {
       [ "//gn/skia:warnings_for_public_headers" ]
 }
 
-if (is_win) {
+if (is_win && !is_mingw) {
   # Windows tool chain
   set_default_toolchain("//gn/toolchain:msvc")
   default_toolchain_name = "msvc"

--- a/gn/is_mingw.py
+++ b/gn/is_mingw.py
@@ -1,0 +1,52 @@
+# A program to check if the compiler passed
+# is a Mingw-w64 based compiler.
+
+import os
+import subprocess
+import argparse
+import sys
+
+
+def is_mingw(CC):
+    if sys.platform != 'win32':
+        # Let's check only if we are in Windows
+        return False
+
+    # Check if the compiler in VS
+    if os.path.basename(CC) in ['cl', 'cl.exe']:
+        return False
+
+    try:
+        com = subprocess.run(
+            [CC, '--version'], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+    except FileNotFoundError:
+        return False
+
+    if com.returncode != 0:
+        # Both gcc and clang compilers from mingw should understand that argument
+        # and should return a status code of 0.
+        return False
+
+    out, err = com.stdout, com.stderr
+    if 'clang' in out or 'Clang' in out:
+        # Check it's not clang-cl wrapper
+        if 'CL.EXE COMPATIBILITY' in out:
+            return False
+
+        return True
+
+    if 'gcc.exe' in out:
+        return True
+
+    return True
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Check if the compiler passed in a mingw based compiler.')
+    parser.add_argument('compiler', help='path to the compiler to check.')
+
+    args = parser.parse_args()
+    CC = args.compiler
+    print('true' if is_mingw(CC) else 'false')

--- a/gn/skia.gni
+++ b/gn/skia.gni
@@ -73,7 +73,7 @@ declare_args() {
   skia_use_webgpu = is_wasm
   skia_use_wuffs = is_wasm
   skia_use_x11 = is_linux
-  skia_use_xps = true
+  skia_use_xps = false
   skia_enable_graphite = false
   skia_use_zlib = true
 

--- a/gn/skia/BUILD.gn
+++ b/gn/skia/BUILD.gn
@@ -60,10 +60,14 @@ config("default") {
   # Disable warnings about unknown attributes.
   # (These unknown attribute warnings are on by default, so we don't make
   # disabling them part of :warnings, as some targets remove :warnings.)
-  if (is_win && !is_clang) {
+  if (is_win && !is_clang && !is_mingw) {
     cflags += [ "/wd5030" ]
   } else {
     cflags += [ "-Wno-attributes" ]
+  }
+  
+  if (is_mingw) {
+    defines += [ "__fastfail=exit" ]
   }
 
   if (is_fuchsia && using_fuchsia_sdk) {
@@ -90,27 +94,50 @@ config("default") {
     if (is_clang && target_cpu == "arm64") {
       cflags += [ "--target=arm64-windows" ]
     }
-    cflags += [
-      "/bigobj",  # Some of our files are bigger than the regular limits.
-      "/utf-8",  # Set Source and Executable character sets to UTF-8.
-    ]
-    cflags_cc += [ "/std:c++17" ]
+    if (!is_mingw){
+      cflags += [
+        "/bigobj",  # Some of our files are bigger than the regular limits.
+        "/utf-8",  # Set Source and Executable character sets to UTF-8.
+      ]
+    } else {
+      cflags += [
+        "-fstrict-aliasing",
+        "-fPIC",
+        "-fvisibility=hidden",
+      ]
+    }
+
+    if (is_mingw){
+      cflags_c += [
+        "-fvisibility-inlines-hidden",
+      ]
+      cflags_cc += [
+        "-std=c++17",
+      ]
+    } else {
+        cflags_cc += [ "/std:c++17" ]
+    }
+
     defines += [
       "_CRT_SECURE_NO_WARNINGS",  # Disables warnings about sscanf().
       "_HAS_EXCEPTIONS=0",  # Disables exceptions in MSVC STL.
       "WIN32_LEAN_AND_MEAN",
       "NOMINMAX",
     ]
+ 
+    if (!is_mingw){
+        _include_dirs = [
+          "$win_vc/Tools/MSVC/$win_toolchain_version/include",
+          "$win_sdk/Include/$win_sdk_version/shared",
+          "$win_sdk/Include/$win_sdk_version/ucrt",
+          "$win_sdk/Include/$win_sdk_version/um",
+          "$win_sdk/Include/$win_sdk_version/winrt",
+        ]
+    } else {
+      _include_dirs = []
+    }
 
-    _include_dirs = [
-      "$win_vc/Tools/MSVC/$win_toolchain_version/include",
-      "$win_sdk/Include/$win_sdk_version/shared",
-      "$win_sdk/Include/$win_sdk_version/ucrt",
-      "$win_sdk/Include/$win_sdk_version/um",
-      "$win_sdk/Include/$win_sdk_version/winrt",
-    ]
-
-    if (is_clang) {
+    if (is_clang && !is_mingw) {
       foreach(dir, _include_dirs) {
         cflags += [
           "-imsvc",
@@ -121,11 +148,15 @@ config("default") {
       include_dirs = _include_dirs
     }
 
-    lib_dirs = [
-      "$win_sdk/Lib/$win_sdk_version/ucrt/$target_cpu",
-      "$win_sdk/Lib/$win_sdk_version/um/$target_cpu",
-      "$win_vc/Tools/MSVC/$win_toolchain_version/lib/$target_cpu",
-    ]
+    if (!is_mingw){
+      lib_dirs = [
+        "$win_sdk/Lib/$win_sdk_version/ucrt/$target_cpu",
+        "$win_sdk/Lib/$win_sdk_version/um/$target_cpu",
+        "$win_vc/Tools/MSVC/$win_toolchain_version/lib/$target_cpu",
+      ]
+    } else {
+      lib_dirs = []
+    }
   } else {
     cflags += [
       "-fstrict-aliasing",
@@ -144,7 +175,7 @@ config("default") {
       "-mfpu=neon",
       "-mthumb",
     ]
-  } else if (current_cpu == "x86" && !is_win) {
+  } else if (current_cpu == "x86" && is_mingw) {
     asmflags += [ "-m32" ]
     cflags += [
       "-m32",
@@ -154,7 +185,7 @@ config("default") {
     ldflags += [ "-m32" ]
   }
 
-  if (malloc != "" && !is_win) {
+  if (malloc != "" && is_mingw) {
     cflags += [
       "-fno-builtin-malloc",
       "-fno-builtin-calloc",
@@ -352,7 +383,7 @@ config("recover_pointer_overflow") {
 
 config("no_exceptions") {
   # Exceptions are disabled by default on Windows.  (Use /EHsc to enable them.)
-  if (!is_win) {
+  if (is_mingw || !is_win) {
     cflags_cc = [ "-fno-exceptions" ]
     cflags_objcc = cflags_cc
   }
@@ -365,14 +396,14 @@ config("warnings") {
   cflags_objcc = []
 
   if (werror) {
-    if (is_win) {
+    if (!is_mingw && is_win) {
       cflags += [ "/WX" ]
     } else {
       cflags += [ "-Werror" ]
     }
   }
 
-  if (is_win) {
+  if (is_win && !is_mingw) {
     cflags += [
       "/W3",  # Turn on lots of warnings.
 
@@ -577,7 +608,7 @@ config("debug_symbols") {
       "-gline-tables-only",
       "-funwind-tables",  # Helps make in-process backtraces fuller.
     ]
-  } else if (is_win) {
+  } else if (is_win && !is_mingw) {
     cflags = [ "/Z7" ]
     if (is_clang) {
       cflags += [ "-gcodeview-ghash" ]
@@ -592,7 +623,7 @@ config("debug_symbols") {
 
 config("no_rtti") {
   if (sanitize != "ASAN") {  # -fsanitize=vptr requires RTTI
-    if (is_win) {
+    if (is_win && !is_mingw) {
       cflags_cc = [ "/GR-" ]
     } else {
       cflags_cc = [ "-fno-rtti" ]
@@ -602,7 +633,7 @@ config("no_rtti") {
 }
 
 config("optimize") {
-  if (is_win) {
+  if (is_win && !is_mingw) {
     cflags = [
       "/O2",
       "/Zc:inline",
@@ -642,7 +673,7 @@ config("executable") {
       "-rdynamic",
       "-Wl,-rpath,\$ORIGIN",
     ]
-  } else if (is_win) {
+  } else if (is_win && !is_mingw) {
     ldflags = [
       "/SUBSYSTEM:CONSOLE",  # Quiet "no subsystem specified; CONSOLE assumed".
       "/INCREMENTAL:NO",  # Quiet warnings about failing to incrementally link

--- a/gn/toolchain/BUILD.gn
+++ b/gn/toolchain/BUILD.gn
@@ -322,6 +322,10 @@ template("gcc_like_toolchain") {
       if (is_mac || is_ios) {
         rpath = "-Wl,-install_name,@rpath/$soname"
       }
+      if (is_mingw) {
+        rpath = ""  # For PE/COFF the soname argument has no effect
+      }
+
 
       rspfile = "{{output}}.rsp"
       rspfile_content = "{{inputs}}"
@@ -339,13 +343,27 @@ template("gcc_like_toolchain") {
         _end_group = ""
       }
 
-      command = "$link -shared {{ldflags}} $_start_group @$rspfile {{frameworks}} {{solibs}} $_end_group {{libs}} $rpath -o {{output}}"
+      _mingw_flags = ""
+      if (is_mingw) {
+        # Have MinGW linker generate a .def file and a .a import library
+        if (!is_clang) {
+          _mingw_flags += " -Wl,--dll "
+        }
+        _mingw_flags +=
+            " -Wl,--output-def=$soname.def -Wl,--out-implib=$soname.a "
+      }
+
+      command = "$link -shared {{ldflags}} $_start_group @$rspfile {{frameworks}} {{solibs}} $_end_group $_mingw_flags {{libs}} $rpath -o {{output}}"
       outputs = [ "{{root_out_dir}}/$soname" ]
       output_prefix = "lib"
       if (is_mac || is_ios) {
         default_output_extension = ".dylib"
       } else {
-        default_output_extension = ".so"
+        if (!is_mingw) {
+          default_output_extension = ".so"
+        } else {
+          default_output_extension = ".dll"
+        }
       }
       description = "link {{output}}"
       if (0 <= link_pool_depth) {

--- a/modules/skshaper/src/SkShaper_harfbuzz.cpp
+++ b/modules/skshaper/src/SkShaper_harfbuzz.cpp
@@ -32,8 +32,8 @@
 #include "src/core/SkTDPQueue.h"
 #include "src/utils/SkUTF.h"
 
-#include <hb.h>
-#include <hb-ot.h>
+#include <harfbuzz/hb.h>
+#include <harfbuzz/hb-ot.h>
 #include <cstring>
 #include <memory>
 #include <type_traits>

--- a/src/pdf/SkPDFSubsetFont.cpp
+++ b/src/pdf/SkPDFSubsetFont.cpp
@@ -9,8 +9,8 @@
 #include "include/private/SkTo.h"
 #include "src/utils/SkCallableTraits.h"
 
-#include "hb.h"
-#include "hb-subset.h"
+#include "harfbuzz/hb.h"
+#include "harfbuzz/hb-subset.h"
 
 template <class T, void(*P)(T*)> using resource =
     std::unique_ptr<T, SkFunctionWrapper<std::remove_pointer_t<decltype(P)>, P>>;

--- a/src/ports/SkFontHost_win.cpp
+++ b/src/ports/SkFontHost_win.cpp
@@ -1073,7 +1073,7 @@ void SkScalerContext_GDI::RGBToA8(const SkGdiRGB* SK_RESTRICT src, size_t srcRB,
         for (int i = 0; i < width; i++) {
             dst[i] = rgb_to_a8<APPLY_PREBLEND>(src[i], table8);
             if constexpr (kSkShowTextBlitCoverage) {
-                dst[i] = std::max(dst[i], 10u);
+                dst[i] = std::max(dst[i], (uint8_t)10u);
             }
         }
         src = SkTAddOffset<const SkGdiRGB>(src, srcRB);

--- a/src/ports/SkImageEncoder_WIC.cpp
+++ b/src/ports/SkImageEncoder_WIC.cpp
@@ -26,7 +26,8 @@
 //but CLSID_WICImagingFactory is then #defined to CLSID_WICImagingFactory2.
 //Undo this #define if it has been done so that we link against the symbols
 //we intended to link against on all SDKs.
-#if defined(CLSID_WICImagingFactory)
+
+#if defined(CLSID_WICImagingFactory) && !defined(__MINGW32__)
 #undef CLSID_WICImagingFactory
 #endif
 

--- a/src/ports/SkImageGeneratorWIC.cpp
+++ b/src/ports/SkImageGeneratorWIC.cpp
@@ -18,7 +18,7 @@
 // but CLSID_WICImagingFactory is then #defined to CLSID_WICImagingFactory2.
 // Undo this #define if it has been done so that we link against the symbols
 // we intended to link against on all SDKs.
-#if defined(CLSID_WICImagingFactory)
+#if defined(CLSID_WICImagingFactory) && !defined(__MINGW32__)
     #undef CLSID_WICImagingFactory
 #endif
 

--- a/src/ports/SkScalerContext_win_dw.cpp
+++ b/src/ports/SkScalerContext_win_dw.cpp
@@ -566,8 +566,13 @@ bool SkScalerContext_DW::isPngGlyph(const SkGlyph& glyph) {
 
     DWRITE_GLYPH_IMAGE_FORMATS f;
     IDWriteFontFace4* fontFace4 = this->getDWriteTypeface()->fDWriteFontFace4.get();
+#if defined(__MINGW32__)
+    HRBM(fontFace4->GetGlyphImageFormats_(glyph.getGlyphID(), 0, UINT32_MAX, &f),
+         "Cannot get glyph image formats.");
+#else
     HRBM(fontFace4->GetGlyphImageFormats(glyph.getGlyphID(), 0, UINT32_MAX, &f),
          "Cannot get glyph image formats.");
+#endif
     return f & DWRITE_GLYPH_IMAGE_FORMATS_PNG;
 }
 
@@ -580,7 +585,7 @@ bool SkScalerContext_DW::isSVGGlyph(const SkGlyph& glyph) {
 
     DWRITE_GLYPH_IMAGE_FORMATS f;
     IDWriteFontFace4* fontFace4 = this->getDWriteTypeface()->fDWriteFontFace4.get();
-    HRBM(fontFace4->GetGlyphImageFormats(glyph.getGlyphID(), 0, UINT32_MAX, &f),
+    HRBM(fontFace4->GetGlyphImageFormats((UINT16)glyph.getGlyphID(), (UINT32)0, UINT32_MAX, &f),
          "Cannot get glyph image formats.");
     return f & DWRITE_GLYPH_IMAGE_FORMATS_SVG;
 }

--- a/src/xps/SkXPSDevice.cpp
+++ b/src/xps/SkXPSDevice.cpp
@@ -318,7 +318,7 @@ bool SkXPSDevice::endSheet() {
     return true;
 }
 
-static HRESULT subset_typeface(const SkXPSDevice::TypefaceUse& current) {
+HRESULT subset_typeface(const SkXPSDevice::TypefaceUse& current) {
     //The CreateFontPackage API is only supported on desktop, not in UWP
     #if defined(SK_WINUWP)
     return E_NOTIMPL;

--- a/third_party/harfbuzz/BUILD.gn
+++ b/third_party/harfbuzz/BUILD.gn
@@ -13,6 +13,9 @@ declare_args() {
 if (skia_use_system_harfbuzz) {
   system("harfbuzz") {
     include_dirs = [ "/usr/include/harfbuzz" ]
+    if (is_mingw) {
+      include_dirs += [ "/usr/include/../clang64/include/harfbuzz" ]
+    }
     libs = [ "harfbuzz" ]
     if (skia_pdf_subset_harfbuzz) {
       libs += [ "harfbuzz-subset" ]

--- a/third_party/third_party.gni
+++ b/third_party/third_party.gni
@@ -17,10 +17,17 @@ template("third_party_config") {
         include_dirs = invoker.include_dirs
         if (is_clang) {
           foreach(dir, invoker.include_dirs) {
-            cflags += [
-              "/imsvc",
-              rebase_path(dir),
-            ]
+            if (!is_mingw) {
+              cflags += [
+                "/imsvc",
+                rebase_path(dir),
+              ]
+            } else {
+              cflags += [
+                "-isystem",
+                rebase_path(dir),
+              ]
+            }
           }
         }
       } else {
@@ -92,7 +99,7 @@ template("third_party") {
       if (!defined(cflags)) {
         cflags = []
       }
-      if (is_win) {
+      if (is_win && !is_mingw) {
         cflags += [ "/w" ]
       } else {
         cflags += [ "-w" ]

--- a/third_party/zlib/BUILD.gn
+++ b/third_party/zlib/BUILD.gn
@@ -50,7 +50,7 @@ if (skia_use_system_zlib) {
     }
 
     # Warnings are just noise if we're not maintaining the code.
-    if (is_win) {
+    if (is_win && !is_mingw) {
       cflags = [ "/w" ]
     } else {
       cflags = [ "-w" ]


### PR DESCRIPTION
Added support for mingw-w64-clang "dream" toolchain v0.1.

The toolchain can be found [here](https://github.com/bigfatbrowncat/dream-toolchain/releases/tag/v0.1)